### PR TITLE
Add noise components and combine with sine waves

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ AcouSynth is a powerful and flexible tool designed for both sound design and aco
 
 AcouSynth includes advanced synthesis techniques for generating harmonic sounds and formants. These techniques allow users to create rich and complex sounds with precise control over their harmonic content and formant structures.
 
+### Combining Sine Waves and Noise Components
+
+AcouSynth now includes the capability to combine sine waves and noise components. This feature allows users to create more complex and realistic sounds by blending harmonic synthesis with noise elements. The user interface in Phase 1 provides controls for basic harmonic synthesis and noise filtering, making it user-friendly and accessible for sound creation.
+
 ## Integration of Theoretical Acoustics with Practical Synthesis
 
 AcouSynth integrates theoretical acoustics with practical synthesis, providing users with a comprehensive toolset for sound design and analysis. This integration allows for the creation of sounds that are both scientifically accurate and musically expressive.
@@ -21,4 +25,5 @@ The Harmonic Sounds and Formants module in AcouSynth is designed to handle harmo
 The Harmonic Sounds and Formants module includes the following features:
 - Functions for generating harmonic sounds with precise control over harmonic content
 - Functions for generating formants with adjustable formant structures
+- Functions for generating noise components and combining them with sine waves
 - Integration with other modules in AcouSynth for seamless sound design and analysis

--- a/src/harmonic_sounds_module.py
+++ b/src/harmonic_sounds_module.py
@@ -37,3 +37,30 @@ def generate_formant_sound(fundamental_freq, formants, duration, sample_rate=441
     for formant_freq, bandwidth in formants:
         sound *= np.exp(-bandwidth * t) * np.sin(2 * np.pi * formant_freq * t)
     return sound
+
+def generate_noise(duration, sample_rate=44100):
+    """
+    Generate a noise component.
+
+    Parameters:
+    - duration: The duration of the noise (in seconds).
+    - sample_rate: The sample rate of the noise (in samples per second).
+
+    Returns:
+    - A numpy array containing the generated noise.
+    """
+    return np.random.normal(0, 1, int(sample_rate * duration))
+
+def combine_sine_and_noise(sine_wave, noise_component, noise_level=0.5):
+    """
+    Combine a sine wave and a noise component.
+
+    Parameters:
+    - sine_wave: A numpy array containing the sine wave data.
+    - noise_component: A numpy array containing the noise component data.
+    - noise_level: The level of the noise component to be combined with the sine wave (default is 0.5).
+
+    Returns:
+    - A numpy array containing the combined sound.
+    """
+    return sine_wave + noise_level * noise_component

--- a/src/integration_module.py
+++ b/src/integration_module.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.signal import find_peaks
+from src.harmonic_sounds_module import combine_sine_and_noise
 
 def integrate_theoretical_acoustics_with_practical_synthesis(sound, sample_rate=44100):
     """
@@ -19,6 +20,9 @@ def integrate_theoretical_acoustics_with_practical_synthesis(sound, sample_rate=
     integrated_sound = generate_harmonic_sound(freqs[0], harmonic_ratios, len(sound) / sample_rate, sample_rate)
     for formant_freq, bandwidth in formants:
         integrated_sound *= np.exp(-bandwidth * np.linspace(0, len(sound) / sample_rate, len(sound))) * np.sin(2 * np.pi * formant_freq * np.linspace(0, len(sound) / sample_rate, len(sound)))
+    
+    noise_component = generate_noise(len(sound) / sample_rate, sample_rate)
+    integrated_sound = combine_sine_and_noise(integrated_sound, noise_component)
     
     return integrated_sound
 


### PR DESCRIPTION
Implement the core synthesis engine to combine sine waves and noise components.

* **`src/harmonic_sounds_module.py`**:
  - Add `generate_noise` function to create noise components.
  - Add `combine_sine_and_noise` function to combine sine waves and noise components.

* **`src/integration_module.py`**:
  - Import `combine_sine_and_noise` from `src/harmonic_sounds_module.py`.
  - Update `integrate_theoretical_acoustics_with_practical_synthesis` to use `combine_sine_and_noise`.

* **`README.md`**:
  - Update features and capabilities to include combining sine waves and noise components.
  - Add a section on combining sine waves and noise components.
  - Update the Harmonic Sounds and Formants module features list to include noise components and their combination with sine waves.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/AcouSynth/pull/2?shareId=f5ea0126-75c0-4f20-93c3-acb76d2f6511).